### PR TITLE
Remove deprecated methods: nextTo[Undo/Redo]

### DIFF
--- a/undofx/src/main/java/org/fxmisc/undo/UndoManager.java
+++ b/undofx/src/main/java/org/fxmisc/undo/UndoManager.java
@@ -61,28 +61,6 @@ public interface UndoManager<C> {
     default C getNextRedo() { return nextRedoProperty().getValue(); }
 
     /**
-     * Gives a peek at the change that will be undone by {@link #undo()}.
-     *
-     * @deprecated use {@link #nextUndoProperty()}
-     */
-    @Deprecated
-    default Val<C> nextToUndoProperty() { return nextUndoProperty(); }
-
-    @Deprecated
-    default C getNextToUndo() { return nextUndoProperty().getValue(); }
-
-    /**
-     * Gives a peek at the change that will be redone by {@link #redo()}.
-     *
-     * @deprecated use {@link #nextRedoProperty()}
-     */
-    @Deprecated
-    default Val<C> nextToRedoProperty() { return nextRedoProperty(); }
-
-    @Deprecated
-    default C getNextToRedo() { return nextRedoProperty().getValue(); }
-
-    /**
      * Indicates whether there is a change that can be redone.
      */
     Val<Boolean> redoAvailableProperty();

--- a/undofx/src/main/java/org/fxmisc/undo/impl/UndoManagerImpl.java
+++ b/undofx/src/main/java/org/fxmisc/undo/impl/UndoManagerImpl.java
@@ -179,17 +179,6 @@ public class UndoManagerImpl<C> implements UndoManager<C> {
         return nextRedo;
     }
 
-
-    @Override
-    public Val<C> nextToUndoProperty() {
-        return nextUndo;
-    }
-
-    @Override
-    public Val<C> nextToRedoProperty() {
-        return nextRedo;
-    }
-
     @Override
     public boolean isUndoAvailable() {
         return nextUndo.isPresent();


### PR DESCRIPTION
In preparation for the next major release due to source incompatible changes made in #26.