### PR TITLE
Improve Documentation on the Change Reinsertion Behavior of the Apply Function

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ Getting an `UndoManager` instance
 ---------------------------------
 
 To get an instance of `UndoManager` you need:
- * a **stream of change events**;
- * a function to **invert** a change;
- * a function to **apply** a change; and
- * optionally, a function to optionally **merge** two subsequent changes into a single change.
+ * a **stream of change events**.
+ * a function to **invert** a change.
+ * a function to **apply** a change. This function must reinsert its parameter into the stream of change events.
+ * optionally, a function to **merge** two subsequent changes into a single change. The first parameter is the old change, and the second parameter is the newer change.
 
 The _stream of change events_ is a [ReactFX](http://www.reactfx.org/) `EventStream`. For an example of how you can construct one, have a look at the source code of the [demo below](#demo).
 

--- a/undofx/src/main/java/org/fxmisc/undo/impl/UndoManagerImpl.java
+++ b/undofx/src/main/java/org/fxmisc/undo/impl/UndoManagerImpl.java
@@ -202,8 +202,9 @@ public class UndoManagerImpl<C> implements UndoManager<C> {
      *
      * @param isChangeAvailable same as `isUndoAvailable()` [Undo] or `isRedoAvailable()` [Redo]
      * @param changeToApply same as `invert.apply(queue.prev())` [Undo] or `queue.next()` [Redo]
+     * @throws IllegalStateException if the applied change was not reinserted into the event stream
      */
-    private boolean applyChange(boolean isChangeAvailable, Supplier<C> changeToApply) {
+    private boolean applyChange(boolean isChangeAvailable, Supplier<C> changeToApply) throws IllegalStateException {
         if (isChangeAvailable) {
             canMerge = false;
 
@@ -213,7 +214,8 @@ public class UndoManagerImpl<C> implements UndoManager<C> {
             performingAction.suspendWhile(() -> apply.accept(change));
             if(this.expectedChange != null) {
                 throw new IllegalStateException("Expected change not received:\n"
-                        + this.expectedChange);
+                        + this.expectedChange
+			+ "\nThe most likely cause is that the apply action did not reinsert the change into the event stream.");
             }
 
             invalidateProperties();


### PR DESCRIPTION
It is now better documented in the
- README
- Exception Message
- Javadoc
that the apply function needs to reinsert its parameter into the event stream.

Closes #30 